### PR TITLE
Use bare /@author/permlink URL and refresh API docs

### DIFF
--- a/react_app/src/containers/api/docs.js
+++ b/react_app/src/containers/api/docs.js
@@ -134,7 +134,10 @@ class ApiDocs extends Component {
                                     </tr>
                                     <tr>
                                         <th>hide_low</th>
-                                        <td>When 1 passed, api skips results with payout below 0.5 or author reputation below 25 <br/> default: 0</td>
+                                        <td>
+                                            When 1 passed, api skips results with payout below 0.5 or author reputation below 25 <br/> default: 0
+                                            <br/><small>Note: author reputation is a snapshot taken at indexing time and is not re-synced when an author's reputation later changes.</small>
+                                        </td>
                                     </tr>
                                     <tr>
                                         <th>include_nsfw</th>

--- a/react_app/src/containers/api/docs.js
+++ b/react_app/src/containers/api/docs.js
@@ -123,11 +123,26 @@ class ApiDocs extends Component {
                                     </tr>
                                     <tr>
                                         <th>sort</th>
-                                        <td>popularity | newest | relevance <br/> default: relevance</td>
+                                        <td>
+                                            popularity | newest | relevance <br/> default: relevance
+                                            <ul>
+                                                <li><strong>relevance</strong> — BM25 text scoring with title and tags weighted higher than body.</li>
+                                                <li><strong>popularity</strong> — favors recent posts with high payout (payout combined with a 30-day recency decay).</li>
+                                                <li><strong>newest</strong> — most recently created first.</li>
+                                            </ul>
+                                        </td>
                                     </tr>
                                     <tr>
                                         <th>hide_low</th>
-                                        <td>When 1 passed, api skips results which has lower payout value than 0.05 <br/> default: 0</td>
+                                        <td>When 1 passed, api skips results with payout below 0.5 or author reputation below 25 <br/> default: 0</td>
+                                    </tr>
+                                    <tr>
+                                        <th>include_nsfw</th>
+                                        <td>When 1 passed, NSFW results are included in the response. NSFW is detected via the <code>is_nsfw</code> flag or a <code>nsfw</code> tag. <br/> default: 0</td>
+                                    </tr>
+                                    <tr>
+                                        <th>votes</th>
+                                        <td>Minimum total vote count. Results with fewer votes are excluded. <br/> default: null</td>
                                     </tr>
                                     <tr>
                                         <th>since</th>
@@ -180,6 +195,15 @@ class ApiDocs extends Component {
                                 <p>The query above searches for posts from @good-karma with two tags together #desktop and
                                     #wallet having exact match of "desktop app" phrase there but excluding posts about
                                     monthly digests or giveaways.</p>
+                            </div>
+                            <div className="doc-section">
+                                <h2>Default filters</h2>
+                                <p>To keep results useful, the following are excluded by default on every query:</p>
+                                <ul>
+                                    <li>Posts marked grayed by the network (downvoted below display threshold).</li>
+                                    <li>Posts with a flag weight of 3 or more.</li>
+                                    <li>NSFW content (detected via the <code>is_nsfw</code> flag or an <code>nsfw</code> tag) — opt in with <code>include_nsfw: 1</code>.</li>
+                                </ul>
                             </div>
                             <div className="doc-section">
                                 <h2>Community search</h2>

--- a/react_app/src/containers/home/index.js
+++ b/react_app/src/containers/home/index.js
@@ -91,7 +91,7 @@ class Home extends Component {
                                                this.submit()
                                            }
                                        }} placeholder={intl.formatMessage({id: "home.search-placeholder"})}/>
-                                <a href="https://ecency.com/esteem/@esteemapp/esteem-search-tips-c42f5a640930best"
+                                <a href="https://ecency.com/@esteemapp/esteem-search-tips-c42f5a640930best"
                                    target="_blank" rel="noopener noreferrer" className="search-tip"
                                    title={intl.formatMessage({id: "home.search-tips"})}>
                                     <Icon icon="info"/>

--- a/react_app/src/utils/linkify.js
+++ b/react_app/src/utils/linkify.js
@@ -1,1 +1,1 @@
-export default (author, permlink) => (`https://ecency.com/post/@${author}/${permlink}`);
+export default (author, permlink) => (`https://ecency.com/@${author}/${permlink}`);


### PR DESCRIPTION
## Summary

- Switch outbound post URLs from `/post/@author/permlink` and `/category/@author/permlink` to the bare `/@author/permlink` form that ecency.com now treats as canonical (matches the canonical/307 rollout)
- Refresh `/search` API docs:
  - Describe each `sort` option (relevance, popularity, newest) and note that popularity now combines payout with a 30-day recency decay
  - Update `hide_low` threshold (payout below 0.5 OR reputation below 25)
  - Document the new `include_nsfw` parameter and the always-on default filters (grayed, heavy-flagged, NSFW)
  - Document the existing `votes` parameter

## Test plan

- [ ] List item on home / results page links to `https://ecency.com/@author/permlink`
- [ ] API docs page renders the updated parameter table and the new "Default filters" section