### PR TITLE
Docs: README launch/config/deploy steps for the modernized stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,95 @@
 # Hivesearcher
 
-Make sure you have redis and python 3 installed, configured on hosting machine
+Web front-end for Hivesearcher — the search UI, the API documentation
+(`/api-docs`) and API-key registration (`/api-register`). A small Flask app
+serves the built single-page app and proxies a few endpoints to the search API.
 
-# Redis
+- **Frontend:** React 18 + Vite (in `react_app/`)
+- **Backend:** Flask + gunicorn (`app.py`)
+- **State:** Redis (caches search responses and holds the indexed document count)
 
-## Mac
+## Configuration
 
-`brew install redis`
+The backend reads its settings from `config.ini` (or from environment
+variables — see below). Copy the example and fill in your own values:
 
-start redis
-
-`brew services restart redis`
-
-## Ubuntu
-
-```
-sudo apt update
-sudo apt install redis-server
-```
-start redis
-
-`sudo systemctl reload redis.service`
-
-# Config.ini
-
-rename `config.ini.example` to `config.ini` and change parameters
-
-# Build webapp
-
-```
-cd react_app/
-npm install
-npm run build
+```bash
+cp config.ini.example config.ini
 ```
 
-# Setup
+| Section       | Key                          | Description                                    |
+| ------------- | ---------------------------- | ---------------------------------------------- |
+| `ESEARCH_API` | `URL`                        | Base URL of the search API                     |
+| `ESEARCH_API` | `TOKEN`                      | API key for the search API                     |
+| `ESEARCH_API` | `REQUEST_TIMEOUT`            | Upstream request timeout (seconds)             |
+| `ESEARCH_API` | `CACHE_TIMEOUT`              | Redis cache TTL for search responses (seconds) |
+| `REDIS`       | `HOST` / `PORT` / `PASS`     | Redis connection                               |
+| `FLASK`       | `DEVELOPMENT` / `DEBUG`      | Flask flags                                    |
 
-`pip3 install -r requirements.txt`
+`config.ini` is gitignored — **never commit real credentials**.
 
-To start webserver run 
+### Environment variable overrides
 
-`python3 app.py`
+Any option can be overridden with an env var named `__ENV__<SECTION>_<OPTION>`,
+for example `__ENV__ESEARCH_API_TOKEN=...` or `__ENV__REDIS_HOST=...`. This is
+useful for containers/CI where you'd rather not keep a config file on disk.
 
+To **update config**, change `config.ini` (or the env vars) and restart the app.
+
+## Local development
+
+Backend (Flask dev server on port 3002) — needs Redis running locally:
+
+```bash
+pip3 install -r requirements.txt
+python3 app.py
+```
+
+Frontend (Vite dev server with hot reload):
+
+```bash
+cd react_app
+yarn install
+yarn dev      # dev server
+yarn build    # production build into react_app/build
+yarn test     # unit tests
+```
+
+In production the Flask app serves the built `react_app/build` directory.
+
+## Production (Docker)
+
+The web image is built with the multi-stage `Dockerfile-web` (Node builds the
+SPA, Python runs Flask/gunicorn on port 5001):
+
+```bash
+docker build -f Dockerfile-web -t hivesearcher-web .
+```
+
+Run it, mounting `config.ini` at `/deploy/config.ini` (keep secrets out of the
+image) and giving it access to your Redis and search API:
+
+```bash
+docker run -d --name hivesearcher-web --restart always \
+  -p 5001:5001 \
+  -v "$PWD/config.ini:/deploy/config.ini:ro" \
+  hivesearcher-web
+```
+
+- **Update config:** edit the mounted `config.ini` (or the `__ENV__*` vars) and
+  restart the container.
+- **Deploy new code:** rebuild the image and recreate the container. Because the
+  config is mounted (not baked into the image), it is preserved across rebuilds.
+
+### Document counter (optional)
+
+`Dockerfile-counter` builds a small worker (`counter/main.py`) that periodically
+writes the indexed document count to Redis (served by the `/api/count`
+endpoint). It uses the same `config.ini` / env configuration:
+
+```bash
+docker build -f Dockerfile-counter -t hivesearcher-counter .
+docker run -d --name hivesearcher-counter --restart always \
+  -v "$PWD/config.ini:/deploy/config.ini:ro" \
+  hivesearcher-counter
+```

--- a/appconfig.py
+++ b/appconfig.py
@@ -25,8 +25,16 @@ class _Interpolation(configparser.Interpolation):
         return _literal_eval(value)
 
 
+# The app's config sections. Seeding them up front lets __ENV__ overrides
+# resolve section names that contain underscores (e.g. ESEARCH_API) even when
+# no config file is present, i.e. for env-only deployments — see
+# _split_section_option().
+_KNOWN_SECTIONS = ('FLASK', 'ESEARCH_API', 'REDIS')
+
 _config = configparser.ConfigParser(interpolation=_Interpolation())
 _config.optionxform = str
+for _section in _KNOWN_SECTIONS:
+    _config.add_section(_section)
 
 
 def _lookup_dirs():

--- a/config.ini.example
+++ b/config.ini.example
@@ -4,8 +4,8 @@ DEVELOPMENT = False
 DEBUG = False
 
 [ESEARCH_API]
-URL = https://api.hivesearcher.com/search
-TOKEN = atokenhere
+URL = https://api.hivesearcher.com
+TOKEN = your-api-key-here
 REQUEST_TIMEOUT = 2
 CACHE_TIMEOUT = 5
 


### PR DESCRIPTION
Updates the README (which still described the old CRA `npm run build` / `python3 app.py` flow) to match the modernized stack and document launching, configuring, and deploying — without any infra-specific details or secrets.

## What

- **Overview** of the app (Vite/React 18 frontend, Flask/gunicorn backend, Redis).
- **Configuration**: copy `config.ini.example` → `config.ini`; table of every section/key; note that it's gitignored.
- **Environment overrides**: documents the `__ENV__<SECTION>_<OPTION>` mechanism (handy for containers/CI with no config file on disk).
- **Local dev**: `python3 app.py` (Flask) + `yarn dev`/`yarn build`/`yarn test` (Vite).
- **Production (Docker)**: `docker build -f Dockerfile-web` + `docker run` with `config.ini` **mounted** at `/deploy/config.ini` (kept out of the image), `--restart always`, and how to update config / redeploy (config survives rebuilds because it's mounted).
- **Optional counter** worker (`Dockerfile-counter`).
- Fixes `config.ini.example`: `ESEARCH_API.URL` set to the base URL (the app appends `/search-paged`, `/stats`, etc.) and a clearer placeholder token.

## Notes

- All commands use generic names/ports (`-p 5001:5001`, `$PWD/config.ini`); no hostnames, IPs, internal network names, real tokens, or deploy paths.
- Production deploy specifics (host paths, network, port mapping, rollback) live in an on-box deploy script, intentionally not in this public repo.